### PR TITLE
Fix ESLint error: escape apostrophe in support page

### DIFF
--- a/src/app/(pages)/support/page.tsx
+++ b/src/app/(pages)/support/page.tsx
@@ -97,7 +97,7 @@ export default function SupportPage() {
               Get in Touch
             </h3>
             <p className="text-gray-700 mb-4">
-              Have questions, suggestions, or want to collaborate? We'd love to hear from you.
+              Have questions, suggestions, or want to collaborate? We&apos;d love to hear from you.
             </p>
             <a
               href="mailto:jeffkazzee@gmail.com"


### PR DESCRIPTION
Replace unescaped apostrophe in 'We'd' with HTML entity &apos; to comply with react/no-unescaped-entities rule.

🤖 Generated with [Claude Code](https://claude.ai/code)